### PR TITLE
feat: add possibility to filter by vulnerability id

### DIFF
--- a/backend/application/core/api/filters.py
+++ b/backend/application/core/api/filters.py
@@ -173,6 +173,9 @@ class ObservationFilter(FilterSet):
     origin_cloud_qualified_resource = CharFilter(
         field_name="origin_cloud_qualified_resource", lookup_expr="icontains"
     )
+    vulnerability_id = CharFilter(
+        field_name="vulnerability_id", lookup_expr="icontains"
+    )
     scanner = CharFilter(field_name="scanner", lookup_expr="icontains")
     age = ChoiceFilter(field_name="age", method="get_age", choices=AGE_CHOICES)
     product_group = ModelChoiceFilter(
@@ -198,6 +201,7 @@ class ObservationFilter(FilterSet):
             ("origin_endpoint_hostname", "origin_endpoint_hostname"),
             ("origin_source_file", "origin_source_file"),
             ("origin_cloud_qualified_resource", "origin_cloud_qualified_resource"),
+            ("vulnerability_id", "vulnerability_id"),
             ("parser__name", "parser_data.name"),
             ("parser__type", "parser_data.type"),
             ("scanner", "scanner_name"),

--- a/frontend/src/core/observations/ObservationEmbeddedList.tsx
+++ b/frontend/src/core/observations/ObservationEmbeddedList.tsx
@@ -71,6 +71,7 @@ function listFilters(product: Product) {
         <TextInput source="origin_endpoint_hostname" label="Host" alwaysOn />,
         <TextInput source="origin_source_file" label="Source" alwaysOn />,
         <TextInput source="origin_cloud_qualified_resource" label="Resource" alwaysOn />,
+        <TextInput source="vulnerability_id" label="Vulnerability ID" alwaysOn />,
         <TextInput source="scanner" alwaysOn />,
         <AutocompleteInputMedium source="age" choices={AGE_CHOICES} alwaysOn />,
         <TextInput source="upload_filename" label="Filename" />,

--- a/frontend/src/core/observations/ObservationList.tsx
+++ b/frontend/src/core/observations/ObservationList.tsx
@@ -49,6 +49,7 @@ const listFilters = [
     <TextInput source="origin_endpoint_hostname" label="Host" />,
     <TextInput source="origin_source_file" label="Source" />,
     <TextInput source="origin_cloud_qualified_resource" label="Resource" />,
+    <TextInput source="vulnerability_id" label="Vulnerability ID" alwaysOn />,
     <TextInput source="scanner" alwaysOn />,
     <AutocompleteInputMedium source="age" choices={AGE_CHOICES} alwaysOn />,
     <NullableBooleanInput source="has_potential_duplicates" label="Duplicates" alwaysOn />,


### PR DESCRIPTION
I think it's useful to be able to filter observations by vulnerability id, both in the observation list of a product ("Is this product affected by this vulnerability? If so, which components?") but mostly in the overall observation list ("Which products / components are affected by this vulnerability?").