### PR TITLE
Fix: References word-break

### DIFF
--- a/frontend/src/commons/layout/themes.ts
+++ b/frontend/src/commons/layout/themes.ts
@@ -35,6 +35,7 @@ export const useStyles = makeStyles()({
         ":visited": {
             color: getLinkColor(),
         },
+        wordBreak: "break-word",
     },
     displayFontSize: {
         fontSize: "0.875rem",


### PR DESCRIPTION
Tiny change. Long links in the "References" section broke the layout. On small screens this also lead to the "Assessment" button on the top right not being visible without scrolling.
Here's how it looked before:
![image](https://github.com/MaibornWolff/SecObserve/assets/16787548/5163a359-7751-4ae5-8209-8e241ea3afb0)

After:
![image](https://github.com/MaibornWolff/SecObserve/assets/16787548/0253f1b8-456b-4354-9473-25c6e70ac7e0)
