### PR TITLE
Fix: add OIDC groups claim

### DIFF
--- a/frontend/src/access_control/authProvider.ts
+++ b/frontend/src/access_control/authProvider.ts
@@ -130,7 +130,7 @@ export const oidcConfig = {
     client_id: window.__RUNTIME_CONFIG__.OIDC_CLIENT_ID,
     redirect_uri: window.__RUNTIME_CONFIG__.OIDC_REDIRECT_URI,
     post_logout_redirect_uri: window.__RUNTIME_CONFIG__.OIDC_POST_LOGOUT_REDIRECT_URI,
-    scope: "openid profile email",
+    scope: "openid profile email groups",
     automaticSilentRenew: true,
     prompt: "select_account",
     onSigninCallback: onSigninCallback,


### PR DESCRIPTION
Adds the `groups` claim to the scope, since it's needed for OIDC group mapping.