### PR TITLE
Feat: allow filtering by 'has pending assessment'

### DIFF
--- a/backend/application/core/api/filters.py
+++ b/backend/application/core/api/filters.py
@@ -203,6 +203,33 @@ class ObservationFilter(FilterSet):
         queryset=Product.objects.filter(is_product_group=True),
     )
 
+    has_pending_assessment = ChoiceFilter(
+        field_name="has_pending_assessment",
+        method="get_has_pending_assessment",
+        choices=[
+            ("true", "true"),
+            ("false", "false"),
+        ],
+    )
+
+    def get_has_pending_assessment(
+        self, queryset, field_name, value
+    ):  # pylint: disable=unused-argument
+        # field_name is used as a positional argument
+
+        if value == "true":
+            return queryset.filter(
+                id__in=Observation_Log.objects.filter(
+                    assessment_status="Needs approval"
+                ).values("observation_id")
+            )
+        else:
+            return queryset.exclude(
+                id__in=Observation_Log.objects.filter(
+                    assessment_status="Needs approval"
+                ).values("observation_id")
+            )
+
     ordering = OrderingFilter(
         # tuple-mapping retains order
         fields=(

--- a/backend/application/core/api/filters.py
+++ b/backend/application/core/api/filters.py
@@ -223,12 +223,12 @@ class ObservationFilter(FilterSet):
                     assessment_status="Needs approval"
                 ).values("observation_id")
             )
-        else:
-            return queryset.exclude(
-                id__in=Observation_Log.objects.filter(
-                    assessment_status="Needs approval"
-                ).values("observation_id")
-            )
+
+        return queryset.exclude(
+            id__in=Observation_Log.objects.filter(
+                assessment_status="Needs approval"
+            ).values("observation_id")
+        )
 
     ordering = OrderingFilter(
         # tuple-mapping retains order

--- a/frontend/src/core/observations/ObservationEmbeddedList.tsx
+++ b/frontend/src/core/observations/ObservationEmbeddedList.tsx
@@ -76,6 +76,7 @@ function listFilters(product: Product) {
         <TextInput source="upload_filename" label="Filename" />,
         <TextInput source="api_configuration_name" label="API configuration" />,
         <NullableBooleanInput source="has_potential_duplicates" label="Duplicates" alwaysOn />,
+        <NullableBooleanInput source="has_pending_assessment" label="Pending assessment" alwaysOn />,
     ];
 }
 

--- a/frontend/src/core/observations/ObservationList.tsx
+++ b/frontend/src/core/observations/ObservationList.tsx
@@ -57,6 +57,7 @@ const listFilters = [
     <TextInput source="scanner" alwaysOn />,
     <AutocompleteInputMedium source="age" choices={AGE_CHOICES} alwaysOn />,
     <NullableBooleanInput source="has_potential_duplicates" label="Duplicates" alwaysOn />,
+    <NullableBooleanInput source="has_pending_assessment" label="Pending assessment" alwaysOn />,
 ];
 
 const ListActions = () => (


### PR DESCRIPTION
Adds the ability to filter observations depending on whether they have pending assessments or not. I found it helpful to hide observations that someone already made an assessment for, even if it has not been approved yet. Gives me a better overview and prevents me from accidentally analyzing a vulnerability that has already been analyzed.