### PR TITLE
feat: zoom buttons for dependency graph

### DIFF
--- a/frontend/src/core/observations/Mermaid_Dependencies.tsx
+++ b/frontend/src/core/observations/Mermaid_Dependencies.tsx
@@ -1,4 +1,6 @@
 import CloseIcon from "@mui/icons-material/Close";
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import ZoomOutIcon from "@mui/icons-material/ZoomOut";
 import { Dialog, DialogContent, DialogTitle, Divider, IconButton, Stack } from "@mui/material";
 import mermaid from "mermaid";
 import { Fragment, useEffect, useState } from "react";
@@ -13,6 +15,12 @@ mermaid.initialize({
     },
 });
 
+function resizeDependencyGraph(scale: number) {
+    const img = document.getElementById("dependency-graph-svg-in-dialog") as HTMLImageElement;
+    img.setAttribute("width", `${img.width * scale}`);
+    img.setAttribute("height", `${img.height * scale}`);
+}
+
 const GraphSVG = () => {
     const svg = document.querySelector(".mermaid svg");
     if (svg == null) {
@@ -22,7 +30,7 @@ const GraphSVG = () => {
     const blob = new Blob([svgData], { type: "image/svg+xml" });
     const url = URL.createObjectURL(blob);
     console.log(url);
-    return <img src={url} alt="Component dependency graph not available" />;
+    return <img src={url} alt="Component dependency graph not available" id="dependency-graph-svg-in-dialog" />;
 };
 
 const createMermaidGraph = (dependencies_str: string) => {
@@ -132,6 +140,14 @@ const MermaidDependencies = () => {
                             </Stack>
                         </DialogTitle>
                         <DialogContent>
+                            <div style={{ position: "absolute", background: "white", right: 0, paddingRight: 24 }}>
+                                <IconButton onClick={() => resizeDependencyGraph(1.1)}>
+                                    <ZoomInIcon />
+                                </IconButton>
+                                <IconButton onClick={() => resizeDependencyGraph(0.9)}>
+                                    <ZoomOutIcon />
+                                </IconButton>
+                            </div>
                             <GraphSVG />
                         </DialogContent>
                     </Dialog>

--- a/frontend/src/core/observations/Mermaid_Dependencies.tsx
+++ b/frontend/src/core/observations/Mermaid_Dependencies.tsx
@@ -1,7 +1,7 @@
+import AddIcon from "@mui/icons-material/Add";
 import CloseIcon from "@mui/icons-material/Close";
-import ZoomInIcon from "@mui/icons-material/ZoomIn";
-import ZoomOutIcon from "@mui/icons-material/ZoomOut";
-import { Dialog, DialogContent, DialogTitle, Divider, IconButton, Stack } from "@mui/material";
+import RemoveIcon from "@mui/icons-material/Remove";
+import { Dialog, DialogContent, DialogTitle, Divider, IconButton, Paper, Stack } from "@mui/material";
 import mermaid from "mermaid";
 import { Fragment, useEffect, useState } from "react";
 import { Labeled, WrapperField, useRecordContext } from "react-admin";
@@ -140,14 +140,15 @@ const MermaidDependencies = () => {
                             </Stack>
                         </DialogTitle>
                         <DialogContent>
-                            <div style={{ position: "absolute", background: "white", right: 0, paddingRight: 24 }}>
+                            <Paper sx={{ position: "absolute", right: 0, marginRight: 3 }}>
                                 <IconButton onClick={() => resizeDependencyGraph(1.1)}>
-                                    <ZoomInIcon />
+                                    <AddIcon />
                                 </IconButton>
+                                <Divider />
                                 <IconButton onClick={() => resizeDependencyGraph(0.9)}>
-                                    <ZoomOutIcon />
+                                    <RemoveIcon />
                                 </IconButton>
-                            </div>
+                            </Paper>
                             <GraphSVG />
                         </DialogContent>
                     </Dialog>


### PR DESCRIPTION
I found that sometimes the texts in the dependency graph are hard to read, if the dependency graph is rather big (or the screen is too small). I added zoom functionality that allows to adjust the graph size, this way huge graphs are better readable on my screen and it's possible to navigate using the horizontal and vertical scrollbars once you zoomed in.