### PR TITLE
fix: ignore observation logs with just comments for CSAF/OpenVEX

### DIFF
--- a/backend/application/core/queries/observation.py
+++ b/backend/application/core/queries/observation.py
@@ -251,3 +251,13 @@ def get_current_observation_log(observation: Observation):
         return Observation_Log.objects.filter(observation=observation).latest("created")
     except Observation_Log.DoesNotExist:
         return None
+
+
+def get_current_modifying_observation_log(observation: Observation):
+    try:
+        return Observation_Log.objects.filter(
+            Q(observation_id=observation.id)
+            & (~Q(status="") | ~Q(severity="") | ~Q(vex_justification=""))
+        ).latest("created")
+    except Observation_Log.DoesNotExist:
+        return None

--- a/backend/application/vex/services/csaf_generator_vulnerability.py
+++ b/backend/application/vex/services/csaf_generator_vulnerability.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from application.core.models import Observation
-from application.core.queries.observation import get_current_observation_log
+from application.core.queries.observation import get_current_modifying_observation_log
 from application.vex.services.csaf_generator_helpers import (
     get_product_or_relationship_id,
     get_vulnerability_ecosystem,
@@ -148,7 +148,7 @@ def set_flag_or_threat(vulnerability: CSAFVulnerability, observation: Observatio
     vex_status = map_status(observation.current_status)
     if vex_status == CSAF_Status.CSAF_STATUS_NOT_AFFECTED:
         product_or_relationship_id = get_product_or_relationship_id(observation)
-        observation_log = get_current_observation_log(observation)
+        observation_log = get_current_modifying_observation_log(observation)
         if observation_log and observation_log.vex_justification:
             found = False
             for flag in vulnerability.flags:

--- a/backend/application/vex/services/openvex_generator.py
+++ b/backend/application/vex/services/openvex_generator.py
@@ -10,7 +10,7 @@ from application.access_control.services.authorization import user_has_permissio
 from application.access_control.services.roles_permissions import Permissions
 from application.commons.services.global_request import get_current_user
 from application.core.models import Branch, Observation, Product
-from application.core.queries.observation import get_current_observation_log
+from application.core.queries.observation import get_current_modifying_observation_log
 from application.core.types import Status
 from application.vex.models import OpenVEX, OpenVEX_Branch, OpenVEX_Vulnerability
 from application.vex.queries.openvex import get_openvex_by_document_id
@@ -336,7 +336,7 @@ def _prepare_statement(observation: Observation) -> Optional[OpenVEXStatement]:
                 "No recommendation for remediation or mitigation available"
             )
     else:
-        observation_log = get_current_observation_log(observation)
+        observation_log = get_current_modifying_observation_log(observation)
         if openvex_status == OpenVEX_Status.OPENVEX_STATUS_NOT_AFFECTED:
             if observation_log:
                 if observation_log.vex_justification:


### PR DESCRIPTION
https://github.com/MaibornWolff/SecObserve/pull/1563 introduced the possiblity to add assessments with just comments, without a further change.

That causes a minor bug, steps to reproduce:
- Create an assessment with Status = "Not affected" and a justification (and optionally approve it)
- Add another assessment with just a comment (does not need approval)
- Now the justification won't be present in the CSAF document once it's generated

This PR makes the CSAF/OpenVEX generation ignore all entries in `observation_log` that do not change at least on of these things: Status, severity, VEX justification