### PR TITLE
fix: compare CSAF components based on id

### DIFF
--- a/backend/application/vex/services/csaf_generator_component.py
+++ b/backend/application/vex/services/csaf_generator_component.py
@@ -48,7 +48,11 @@ def append_component_to_product_tree(
         components_branch.branches = []
 
     for component_branch in components_branch.branches:
-        if component_branch.name == observation.origin_component_name_version:
+        if component_branch.product and component_branch.product.product_id == get_component_id(
+            observation.origin_component_name_version,
+            observation.origin_component_purl,
+            observation.origin_component_cpe,
+        ):
             return
 
     component_branch = CSAFProductBranch(

--- a/backend/application/vex/services/csaf_generator_component.py
+++ b/backend/application/vex/services/csaf_generator_component.py
@@ -48,10 +48,14 @@ def append_component_to_product_tree(
         components_branch.branches = []
 
     for component_branch in components_branch.branches:
-        if component_branch.product and component_branch.product.product_id == get_component_id(
-            observation.origin_component_name_version,
-            observation.origin_component_purl,
-            observation.origin_component_cpe,
+        if (
+            component_branch.product
+            and component_branch.product.product_id
+            == get_component_id(
+                observation.origin_component_name_version,
+                observation.origin_component_purl,
+                observation.origin_component_cpe,
+            )
         ):
             return
 


### PR DESCRIPTION
Currently, when adding components, it is checked whether they are already present based on the component name. That works in most cases, but sometimes two components have the same name, but different IDs.

For example, when I want to publish a VEX about a product that I ship in different CPU architectures (aarch64 and x86_64). I create two assessments for both products but want to publish both assessments in one CSAF document. Then the following components may be present in the CSAF product tree:

Name: openssl:1:3.0.7-27.el9
ID: pkg:rpm/rhel/openssl@3.0.7-27.el9?arch=x86_64&epoch=1&upstream=openssl-3.0.7-27.el9.src.rpm&distro=rhel-9.4

Name: openssl:1:3.0.7-27.el9
ID: pkg:rpm/rhel/openssl@3.0.7-27.el9?arch=aarch64&epoch=1&upstream=openssl-3.0.7-27.el9.src.rpm&distro=rhel-9.4