### PR TITLE
fix: add all component relationships in CSAF document

### DIFF
--- a/backend/application/vex/services/csaf_generator_component.py
+++ b/backend/application/vex/services/csaf_generator_component.py
@@ -44,6 +44,8 @@ def append_component_to_product_tree(
         )
         product_tree.branches.append(components_branch)
 
+    _append_component_to_relationships(product_tree, observation)
+
     if not components_branch.branches:
         components_branch.branches = []
 
@@ -61,8 +63,6 @@ def append_component_to_product_tree(
         ),
     )
     components_branch.branches.append(component_branch)
-
-    _append_component_to_relationships(product_tree, observation)
 
 
 def _create_component(

--- a/backend/unittests/vex/api/files/csaf_given_vulnerability.json
+++ b/backend/unittests/vex/api/files/csaf_given_vulnerability.json
@@ -111,6 +111,15 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
+                    "name": "vex_comp_2:2.0.0@vex_product_2:dev",
+                    "product_id": "vex_comp_2:2.0.0@vex_product_2:dev"
+                },
+                "product_reference": "pkg:so/vex_comp_2@2.0.0",
+                "relates_to_product_reference": "pkg:so/vex_product_2@dev"
+            },
+            {
+                "category": "default_component_of",
+                "full_product_name": {
                     "name": "vex_comp_4:4.0.0@vex_product_2:dev",
                     "product_id": "vex_comp_4:4.0.0@vex_product_2:dev"
                 },

--- a/backend/unittests/vex/api/files/csaf_given_vulnerability_update.json
+++ b/backend/unittests/vex/api/files/csaf_given_vulnerability_update.json
@@ -116,6 +116,15 @@
             {
                 "category": "default_component_of",
                 "full_product_name": {
+                    "name": "vex_comp_2:2.0.0@vex_product_2:dev",
+                    "product_id": "vex_comp_2:2.0.0@vex_product_2:dev"
+                },
+                "product_reference": "pkg:so/vex_comp_2@2.0.0",
+                "relates_to_product_reference": "pkg:so/vex_product_2@dev"
+            },
+            {
+                "category": "default_component_of",
+                "full_product_name": {
                     "name": "vex_comp_4:4.0.0@vex_product_2:dev",
                     "product_id": "vex_comp_4:4.0.0@vex_product_2:dev"
                 },

--- a/backend/unittests/vex/api/test_views_csaf.py
+++ b/backend/unittests/vex/api/test_views_csaf.py
@@ -465,7 +465,7 @@ class TestCSAF(TestCase):
         self.assertEqual(None, csaf.product)
         self.assertEqual(1, csaf.version)
         self.assertEqual(
-            "ec47edfbb1591512e09686a7985f9d15b0ebda2919d000e8e699d943a72af210",
+            "b4a6c3264182f1e5ae292a7386f169c04d5a0f93ef44c652ef9a97ebee71d0c8",
             csaf.content_hash,
         )
         self.assertEqual("Title", csaf.title)
@@ -561,7 +561,7 @@ class TestCSAF(TestCase):
         self.assertEqual(None, csaf.product)
         self.assertEqual(2, csaf.version)
         self.assertEqual(
-            "532ef0d4fab088458b404687885fabe2ba9cc171f14f517751753e463a44e1c9",
+            "b3d5d54c989a8906100d2dcb4ccc8078d3daea6ad323ba52e55d1aa8c3c61771",
             csaf.content_hash,
         )
         self.assertEqual("Title", csaf.title)


### PR DESCRIPTION
When I create a CSAF document for a specific vulnerability that affects multiple products, only the component relationships to the first product are inserted into the CSAF relationships.

Example:
A vulnerability in a component named `ncurses-base:6.2-10.20210508.el9` is found. It affects my products "HBase" and "Druid" (the "main" branch for both products). I create an assessment and create a CSAF VEX doc for that vulnerability, without specifying a product.
Then this is added to the relationships:
```
{
    "category": "default_component_of",
    "full_product_name": {
        "name": "ncurses-base:6.2-10.20210508.el9@Druid:main",
        "product_id": "ncurses-base:6.2-10.20210508.el9@Druid:main"
    },
    "product_reference": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9?arch=noarch&distro=redhat-9.4",
    "relates_to_product_reference": "Druid:main"
}
```

But this is missing:
```
{
    "category": "default_component_of",
    "full_product_name": {
        "name": "ncurses-base:6.2-10.20210508.el9@HBase:main",
        "product_id": "ncurses-base:6.2-10.20210508.el9@HBase:main"
    },
    "product_reference": "pkg:rpm/redhat/ncurses-base@6.2-10.20210508.el9?arch=noarch&distro=redhat-9.4",
    "relates_to_product_reference": "HBase:main"
}
```

The fix adds relationships, even if a component is already present in the `_components_` branch (because it was already found in another product).