### PR TITLE
feat: bulk delete functionality for own assessments

### DIFF
--- a/backend/application/core/api/serializers_observation.py
+++ b/backend/application/core/api/serializers_observation.py
@@ -615,6 +615,12 @@ class ObservationLogBulkApprovalSerializer(Serializer):
     )
 
 
+class ObservationLogBulkDeleteSerializer(Serializer):
+    observation_logs = ListField(
+        child=IntegerField(min_value=1), min_length=0, max_length=100, required=True
+    )
+
+
 class PotentialDuplicateSerializer(ModelSerializer):
     potential_duplicate_observation = NestedObservationSerializer()
 

--- a/frontend/src/core/observation_logs/AssessmentDeleteApproval.tsx
+++ b/frontend/src/core/observation_logs/AssessmentDeleteApproval.tsx
@@ -1,8 +1,7 @@
-import CancelIcon from "@mui/icons-material/Cancel";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { Backdrop, Button, CircularProgress, Dialog, DialogContent, DialogTitle } from "@mui/material";
+import { Backdrop, Button, CircularProgress } from "@mui/material";
 import { Fragment, useState } from "react";
-import { useListContext, useNotify, useRefresh, useUnselectAll } from "react-admin";
+import { Confirm, useListContext, useNotify, useRefresh, useUnselectAll } from "react-admin";
 
 import { httpClient } from "../../commons/ra-data-django-rest-framework";
 
@@ -45,31 +44,8 @@ const AssessmentDeleteApproval = () => {
             });
     };
 
-    const handleClose = (event: object, reason: string) => {
-        if (reason && reason == "backdropClick") return;
-        setOpen(false);
-    };
-
     const handleCancel = () => setOpen(false);
-
     const handleOpen = () => setOpen(true);
-
-    const CancelButton = () => (
-        <Button
-            sx={{
-                mr: "1em",
-                direction: "row",
-                justifyContent: "center",
-                alignItems: "center",
-            }}
-            variant="contained"
-            onClick={handleCancel}
-            color="inherit"
-            startIcon={<CancelIcon />}
-        >
-            Cancel
-        </Button>
-    );
 
     return (
         <Fragment>
@@ -81,19 +57,13 @@ const AssessmentDeleteApproval = () => {
             >
                 Delete
             </Button>
-            <Dialog open={open && !loading} onClose={handleClose}>
-                <DialogTitle sx={{ display: "flex", alignItems: "center" }}>
-                    <DeleteIcon />
-                    &nbsp;&nbsp;Delete assessments
-                </DialogTitle>
-                <DialogContent>
-                    <p>Are you sure you want to delete the selected assessments?</p>
-                    <CancelButton />
-                    <Button onClick={assessmentDelete} variant="contained" color="primary">
-                        Confirm deletion
-                    </Button>
-                </DialogContent>
-            </Dialog>
+            <Confirm
+                isOpen={open}
+                title="Delete assessments"
+                content={"Are you sure you want to delete the selected assessments?"}
+                onConfirm={assessmentDelete}
+                onClose={handleCancel}
+            />
             {loading ? (
                 <Backdrop sx={{ color: "#fff", zIndex: (theme) => theme.zIndex.drawer + 1 }} open={open}>
                     <CircularProgress color="primary" />

--- a/frontend/src/core/observation_logs/AssessmentDeleteApproval.tsx
+++ b/frontend/src/core/observation_logs/AssessmentDeleteApproval.tsx
@@ -1,0 +1,106 @@
+import CancelIcon from "@mui/icons-material/Cancel";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { Backdrop, Button, CircularProgress, Dialog, DialogContent, DialogTitle } from "@mui/material";
+import { Fragment, useState } from "react";
+import { useListContext, useNotify, useRefresh, useUnselectAll } from "react-admin";
+
+import { httpClient } from "../../commons/ra-data-django-rest-framework";
+
+const AssessmentDeleteApproval = () => {
+    const [open, setOpen] = useState(false);
+    const refresh = useRefresh();
+    const notify = useNotify();
+    const { selectedIds } = useListContext();
+    const unselectAll = useUnselectAll("observation_logs");
+    const [loading, setLoading] = useState(false);
+
+    const assessmentDelete = async () => {
+        setLoading(true);
+        const deleteBody = {
+            observation_logs: selectedIds,
+        };
+
+        httpClient(window.__RUNTIME_CONFIG__.API_BASE_URL + "/observation_logs/bulk_delete/", {
+            method: "DELETE",
+            body: JSON.stringify(deleteBody),
+        })
+            .then((response) => {
+                refresh();
+                setOpen(false);
+                setLoading(false);
+                unselectAll();
+                const count = response.json.count;
+                notify(`${count} assessment${count === 1 ? "" : "s"} deleted`, {
+                    type: "success",
+                });
+            })
+            .catch((error) => {
+                refresh();
+                setOpen(false);
+                setLoading(false);
+                unselectAll();
+                notify(error.message, {
+                    type: "warning",
+                });
+            });
+    };
+
+    const handleClose = (event: object, reason: string) => {
+        if (reason && reason == "backdropClick") return;
+        setOpen(false);
+    };
+
+    const handleCancel = () => setOpen(false);
+
+    const handleOpen = () => setOpen(true);
+
+    const CancelButton = () => (
+        <Button
+            sx={{
+                mr: "1em",
+                direction: "row",
+                justifyContent: "center",
+                alignItems: "center",
+            }}
+            variant="contained"
+            onClick={handleCancel}
+            color="inherit"
+            startIcon={<CancelIcon />}
+        >
+            Cancel
+        </Button>
+    );
+
+    return (
+        <Fragment>
+            <Button
+                onClick={handleOpen}
+                size="small"
+                sx={{ paddingTop: "0px", paddingBottom: "2px" }}
+                startIcon={<DeleteIcon />}
+            >
+                Delete
+            </Button>
+            <Dialog open={open && !loading} onClose={handleClose}>
+                <DialogTitle sx={{ display: "flex", alignItems: "center" }}>
+                    <DeleteIcon />
+                    &nbsp;&nbsp;Delete assessments
+                </DialogTitle>
+                <DialogContent>
+                    <p>Are you sure you want to delete the selected assessments?</p>
+                    <CancelButton />
+                    <Button onClick={assessmentDelete} variant="contained" color="primary">
+                        Confirm deletion
+                    </Button>
+                </DialogContent>
+            </Dialog>
+            {loading ? (
+                <Backdrop sx={{ color: "#fff", zIndex: (theme) => theme.zIndex.drawer + 1 }} open={open}>
+                    <CircularProgress color="primary" />
+                </Backdrop>
+            ) : null}
+        </Fragment>
+    );
+};
+
+export default AssessmentDeleteApproval;

--- a/frontend/src/core/observation_logs/ObservationLogApprovalList.tsx
+++ b/frontend/src/core/observation_logs/ObservationLogApprovalList.tsx
@@ -21,15 +21,17 @@ import { getSettingListSize } from "../../commons/user_settings/functions";
 import { ASSESSMENT_STATUS_NEEDS_APPROVAL } from "../types";
 import { OBSERVATION_SEVERITY_CHOICES, OBSERVATION_STATUS_CHOICES } from "../types";
 import AssessmentBulkApproval from "./AssessmentBulkApproval";
+import AssessmentDeleteApproval from "./AssessmentDeleteApproval";
 import { commentShortened } from "./functions";
 
 const BulkActionButtons = ({ product }: any) => {
     return (
-        <Fragment>
-            {(!product || (product && product.permissions.includes(PERMISSION_OBSERVATION_LOG_APPROVAL))) && (
+        (!product || (product && product.permissions.includes(PERMISSION_OBSERVATION_LOG_APPROVAL))) && (
+            <Fragment>
                 <AssessmentBulkApproval />
-            )}
-        </Fragment>
+                <AssessmentDeleteApproval />
+            </Fragment>
+        )
     );
 };
 
@@ -170,9 +172,11 @@ const ObservationLogApprovalList = ({ product }: ObservationLogApprovalListProps
                         size={getSettingListSize()}
                         sx={{ width: "100%" }}
                         bulkActionButtons={
-                            (!product ||
-                                (product && product.permissions.includes(PERMISSION_OBSERVATION_LOG_APPROVAL))) && (
+                            !product ||
+                            (product && product.permissions.includes(PERMISSION_OBSERVATION_LOG_APPROVAL)) ? (
                                 <BulkActionButtons product={product} />
+                            ) : (
+                                false
                             )
                         }
                         rowClick={ShowObservationLogs}

--- a/frontend/src/core/observation_logs/ObservationLogApprovalList.tsx
+++ b/frontend/src/core/observation_logs/ObservationLogApprovalList.tsx
@@ -1,3 +1,5 @@
+import { Stack } from "@mui/material";
+import { Fragment } from "react";
 import {
     AutocompleteInput,
     Datagrid,
@@ -11,7 +13,6 @@ import {
     TextInput,
     useListController,
 } from "react-admin";
-import { Fragment } from "react/jsx-runtime";
 
 import { PERMISSION_OBSERVATION_LOG_APPROVAL } from "../../access_control/types";
 import { CustomPagination } from "../../commons/custom_fields/CustomPagination";
@@ -26,12 +27,14 @@ import { commentShortened } from "./functions";
 
 const BulkActionButtons = ({ product }: any) => {
     return (
-        (!product || (product && product.permissions.includes(PERMISSION_OBSERVATION_LOG_APPROVAL))) && (
-            <Fragment>
-                <AssessmentBulkApproval />
-                <AssessmentDeleteApproval />
-            </Fragment>
-        )
+        <Fragment>
+            {(!product || (product && product.permissions.includes(PERMISSION_OBSERVATION_LOG_APPROVAL))) && (
+                <Stack direction="row" spacing={2} alignItems="center">
+                    <AssessmentBulkApproval />
+                    <AssessmentDeleteApproval />
+                </Stack>
+            )}
+        </Fragment>
     );
 };
 


### PR DESCRIPTION
This PR adds the ability to bulk delete your own assessments in the "Observation Log Approvals" screen. I think this is useful if you made a mistake in a bulk assessment.