### PR TITLE
fix: Allow environment Debug to be set from Environment variable in order to be able to debug production images/containers when there is a problem.

### DIFF
--- a/backend/config/settings/dev.py
+++ b/backend/config/settings/dev.py
@@ -1,9 +1,10 @@
 from .base import *  # noqa NOSONAR
+import os
 
 # GENERAL
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#debug
-DEBUG = True
+DEBUG = os.environ.get("DEBUG", "True")
 
 # MIDDLEWARE
 # ------------------------------------------------------------------------------

--- a/backend/config/settings/dist.py
+++ b/backend/config/settings/dist.py
@@ -1,10 +1,11 @@
 from .base import *  # noqa NOSONAR
 from .base import env
+import os
 
 # GENERAL
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#debug
-DEBUG = True
+DEBUG = os.environ.get("DEBUG", "False")
 
 # MIDDLEWARE
 # ------------------------------------------------------------------------------

--- a/backend/config/settings/prod.py
+++ b/backend/config/settings/prod.py
@@ -1,9 +1,10 @@
 from .base import *  # noqa
+import os
 
 # GENERAL
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#debug
-DEBUG = False
+DEBUG = os.environ.get("DEBUG", "False")
 
 # STATIC
 # ------------------------


### PR DESCRIPTION
 fix: Allow environment Debug to be set from Environment variable in order to be able to debug production images/containers when there is a problem. #3834 