### PR TITLE
fix: use safe theme resolver in Mermaid dependency graph

### DIFF
--- a/frontend/src/commons/user_settings/functions.ts
+++ b/frontend/src/commons/user_settings/functions.ts
@@ -60,7 +60,7 @@ export function getSettingTheme(): string {
     const user = localStorage.getItem("user");
     if (user) {
         const user_json = JSON.parse(user);
-        theme = user_json.setting_theme;
+        theme = user_json.setting_theme ?? theme;
     } else if (storage_theme) {
         theme = storage_theme;
     }

--- a/frontend/src/core/observations/Mermaid_Dependencies.tsx
+++ b/frontend/src/core/observations/Mermaid_Dependencies.tsx
@@ -7,7 +7,7 @@ import { Fragment, useEffect, useState } from "react";
 import { Labeled, WrapperField } from "react-admin";
 
 import LabeledTextField from "../../commons/custom_fields/LabeledTextField";
-import { getTheme } from "../../commons/user_settings/functions";
+import { getResolvedSettingTheme } from "../../commons/user_settings/functions";
 
 mermaid.initialize({
     flowchart: {
@@ -40,9 +40,9 @@ const createMermaidGraph = (dependencies_str: string) => {
     if (dependencies.length > 500) {
         return "Error: Graph is too large, it has more than 500 dependencies";
     }
-    const line_color = getTheme() == "dark" ? "white" : "black";
-    const primary_color = getTheme() == "dark" ? "#0086B4" : "#C9F1FF";
-    const primary_text_color = getTheme() == "dark" ? "white" : "black";
+    const line_color = getResolvedSettingTheme() == "dark" ? "white" : "black";
+    const primary_color = getResolvedSettingTheme() == "dark" ? "#0086B4" : "#C9F1FF";
+    const primary_text_color = getResolvedSettingTheme() == "dark" ? "white" : "black";
     let mermaid_content =
         "---\n" +
         "  config:\n" +


### PR DESCRIPTION
## Probable cause: `79ebb55d` — "Follow System" theme option (#3898)

`Mermaid_Dependencies.tsx` was not modified, but its dependency `getTheme()` was changed.

**Before** — always returned `"dark"` or `"light"`, even for unexpected input:
```typescript
if (setting_theme == "dark") return "dark";
else return "light";
```

**After** — passes `getSettingTheme()` through `resolveTheme()`, which returns the value as-is unless it's `"system"`:
```typescript
return resolveTheme(getSettingTheme() as ThemePreference);
```

`getSettingTheme()` can return `undefined` when `user_json.setting_theme` is unset, and the new code path propagates that `undefined` instead of falling back to `"light"`.

### Consistency gap

All other theme callers were updated to use the safe `getResolvedSettingTheme()` (which defaults unknown values to `"light"` via `castThemePreference()`). `Mermaid_Dependencies.tsx` was missed.

## Pre-existing fragilities in `createMermaidGraph()`

The `replaceAll` on lines 82-86 operates on the entire string including the YAML front matter:
- A versionless component named `Roboto`, `base`, or `LR` would corrupt the YAML header.
- Component names containing `"`, `(`, or `)` produce invalid Mermaid node syntax.

## Changes

1. Use `getResolvedSettingTheme` in `Mermaid_Dependencies.tsx` instead of `getTheme`.
2. Guard `getSettingTheme()` against undefined: `theme = user_json.setting_theme ?? theme;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)