### PR TITLE
fix: re-render Mermaid dependency graph on theme switch

### DIFF
--- a/frontend/src/core/observations/Mermaid_Dependencies.tsx
+++ b/frontend/src/core/observations/Mermaid_Dependencies.tsx
@@ -3,8 +3,8 @@ import CloseIcon from "@mui/icons-material/Close";
 import RemoveIcon from "@mui/icons-material/Remove";
 import { Dialog, DialogContent, DialogTitle, Divider, IconButton, Paper, Stack } from "@mui/material";
 import mermaid from "mermaid";
-import { Fragment, useEffect, useState } from "react";
-import { Labeled, WrapperField } from "react-admin";
+import { Fragment, useEffect, useRef, useState } from "react";
+import { Labeled, WrapperField, useTheme } from "react-admin";
 
 import LabeledTextField from "../../commons/custom_fields/LabeledTextField";
 import { getResolvedSettingTheme } from "../../commons/user_settings/functions";
@@ -94,6 +94,8 @@ type ComponentShowProps = {
 
 const MermaidDependencies = ({ dependencies }: ComponentShowProps) => {
     const [open, setOpen] = useState(false);
+    const [theme] = useTheme();
+    const mermaidRef = useRef<HTMLAnchorElement>(null);
     const handleOpen = () => {
         setOpen(true);
     };
@@ -103,13 +105,13 @@ const MermaidDependencies = ({ dependencies }: ComponentShowProps) => {
     };
 
     useEffect(() => {
-        if (dependencies) {
-            if (document.getElementById("mermaid-dependencies")) {
-                document.getElementById("mermaid-dependencies")?.removeAttribute("data-processed");
-                mermaid.contentLoaded();
-            }
+        if (dependencies && mermaidRef.current) {
+            const element = mermaidRef.current;
+            element.removeAttribute("data-processed");
+            element.innerHTML = createMermaidGraph(dependencies);
+            mermaid.run({ nodes: [element] });
         }
-    }, [dependencies, mermaid.contentLoaded()]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [dependencies, theme]);
 
     return (
         <Fragment>
@@ -120,6 +122,7 @@ const MermaidDependencies = ({ dependencies }: ComponentShowProps) => {
                             <a
                                 href="javasrcipt:void(0);"
                                 id="mermaid-dependencies"
+                                ref={mermaidRef}
                                 className="mermaid"
                                 onClick={handleOpen}
                             >


### PR DESCRIPTION
## Summary
- Fixed Mermaid dependency graph showing raw source text instead of rendered diagram when toggling theme (light/dark/system)
- Replaced broken `useEffect` dependency array (contained `mermaid.contentLoaded()` function call as side effect) with proper `[dependencies, theme]` dependencies
- Used `useTheme` from react-admin and `mermaid.run()` (v11.x API) for reliable re-rendering via a ref

## Test plan
- [x] Open an observation with a component dependency graph
- [x] Toggle theme (light -> dark -> system -> light) and verify the graph re-renders with correct colors each time
- [x] Verify the graph remains clickable to open the fullscreen dialog
- [x] Run `npm run build` to confirm no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)