### PR TITLE
fix: chart release workflow

### DIFF
--- a/.github/workflows/release_helm_chart.yaml
+++ b/.github/workflows/release_helm_chart.yaml
@@ -1,6 +1,7 @@
 name: Publish released chart
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Converts the repository owner to lowercase to avoid problems due to the OCI spec disallowing upper case letters in image references